### PR TITLE
Fix build to include sources in sourcemap for TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "normalize-scroll-left",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true
   },
   "files": [


### PR DESCRIPTION
TypeScript tries to load a sourcemap from the non-existant src folder and produces the following warning:

```
WARNING in ./node_modules/normalize-scroll-left/lib/main.js
(Emitted value instead of an instance of Error) Cannot find source file '../src/main.ts': Error: Can't resolve '../src/main.ts' in '/home/peter/Development/reflexivity/ui/node_modules/normalize-scroll-left/lib'
```

Note that this probably isn't an issue with sourcemaps disabled.

As I see it, there are two fixes. Either include the raw source or inline the source in the sourcemap. I've chosen the latter in this PR.