### PR TITLE
Support esm with module field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 *.log
 *~
-lib
+cjs
+esm

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "balanced-match": {
@@ -75,7 +75,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -91,12 +91,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -105,11 +105,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "check-error": {
@@ -124,7 +124,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -172,7 +172,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.3"
+        "type-detect": "^4.0.0"
       }
     },
     "diff": {
@@ -187,7 +187,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "1.1.6",
+        "esutils": "^1.1.6",
         "isarray": "0.0.1"
       },
       "dependencies": {
@@ -217,10 +217,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "errno": {
@@ -229,7 +229,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "escape-string-regexp": {
@@ -262,12 +262,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -288,7 +288,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -309,7 +309,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "inflight": {
@@ -318,8 +318,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -352,9 +352,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "make-error": {
@@ -369,8 +369,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "minimatch": {
@@ -379,7 +379,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -427,7 +427,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -450,7 +450,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parse-passwd": {
@@ -495,13 +495,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "resolve": {
@@ -510,7 +510,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "rimraf": {
@@ -519,7 +519,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
@@ -546,7 +546,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "string_decoder": {
@@ -555,7 +555,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -564,7 +564,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -597,10 +597,10 @@
       "integrity": "sha512-8t3bu2FcEkXb+D4L+Cn8qiK2E2C6Ms4/GQChvz6IMbVurcFHLXrhW4EMtfaol1a1ASQACZGDUGit4NHnX9g7hQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0",
-        "enhanced-resolve": "3.4.1",
-        "loader-utils": "1.1.0",
-        "semver": "5.4.1"
+        "chalk": "^2.0.1",
+        "enhanced-resolve": "^3.0.0",
+        "loader-utils": "^1.0.2",
+        "semver": "^5.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -609,7 +609,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -618,9 +618,9 @@
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "has-flag": {
@@ -635,7 +635,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -646,16 +646,16 @@
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.1.0",
-        "diff": "3.2.0",
-        "make-error": "1.3.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18",
-        "tsconfig": "6.0.0",
-        "v8flags": "3.0.1",
-        "yn": "2.0.0"
+        "arrify": "^1.0.0",
+        "chalk": "^2.0.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.0",
+        "tsconfig": "^6.0.0",
+        "v8flags": "^3.0.0",
+        "yn": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -664,7 +664,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -673,9 +673,9 @@
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "has-flag": {
@@ -696,7 +696,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "v8flags": {
@@ -705,7 +705,7 @@
           "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1"
+            "homedir-polyfill": "^1.0.1"
           }
         }
       }
@@ -716,8 +716,8 @@
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       }
     },
     "tslib": {
@@ -732,16 +732,16 @@
       "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "diff": "3.2.0",
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.4.0",
-        "semver": "5.4.1",
-        "tslib": "1.7.1",
-        "tsutils": "2.10.0"
+        "babel-code-frame": "^6.22.0",
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.7.1",
+        "tsutils": "^2.8.1"
       }
     },
     "tslint-eslint-rules": {
@@ -750,9 +750,9 @@
       "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
       "dev": true,
       "requires": {
-        "doctrine": "0.7.2",
-        "tslib": "1.7.1",
-        "tsutils": "1.9.1"
+        "doctrine": "^0.7.2",
+        "tslib": "^1.0.0",
+        "tsutils": "^1.4.0"
       },
       "dependencies": {
         "tsutils": {
@@ -769,7 +769,7 @@
       "integrity": "sha1-Mo7pwo0HzfeTKTIEyW4v+rkiGZQ=",
       "dev": true,
       "requires": {
-        "tsutils": "1.9.1"
+        "tsutils": "^1.4.0"
       },
       "dependencies": {
         "tsutils": {
@@ -786,7 +786,7 @@
       "integrity": "sha1-rpRRHfJlbrBuRCQFb7pcOIiHBAw=",
       "dev": true,
       "requires": {
-        "tslib": "1.7.1"
+        "tslib": "^1.7.1"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "email": "ali.taheri.m@gmail.com"
   },
   "files": [
-    "lib"
+    "cjs",
+    "esm"
   ],
   "repository": {
     "type": "git",
@@ -23,14 +24,15 @@
     "element"
   ],
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "rimraf cjs esm && tsc --module commonjs --outDir cjs && tsc --module es6 --outDir esm",
     "prepublishOnly": "npm run build",
     "lint": "tslint -e \"node_modules/**\" \"src/**/*.ts\"",
     "test": "mocha --compilers ts:ts-node/register \"src/**/*.spec.ts\""
   },
   "license": "MIT",
-  "main": "lib/main.js",
-  "types": "lib/main.d.ts",
+  "main": "cjs/main.js",
+  "module": "esm/main.js",
+  "types": "cjs/main.d.ts",
   "devDependencies": {
     "@types/chai": "^4.0.4",
     "@types/mocha": "^2.2.43",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
     "target": "es5",
-    "module": "commonjs",
     "alwaysStrict": true,
     "noEmitOnError": false,
     "strictNullChecks": true,


### PR DESCRIPTION
In this diff I added esm support with module field in package.json.
It will allow bundlers like rollup to skip commonjs to esm conversion
and reduce heavy memory usage.