### PR TITLE
work around chrome 85 scrollLeft bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,8 @@ export function detectScrollType(): ScrollType {
   if (dummy.scrollLeft > 0) {
     cachedType = 'default';
   } else {
-    dummy.scrollLeft = 1;
-    if (dummy.scrollLeft === 0) {
+    dummy.scrollLeft = 2;
+    if (dummy.scrollLeft < 2) {
       cachedType = 'negative';
     }
   }


### PR DESCRIPTION
This change intends to work around a bug introduced by Chrome version 85. In this version Chrome now implemented the standard/negative scrollLeft calculation, but it also brought in a bug where scrollLeft of an RTL container could be at maximum 1 whereas the maximum should be 0 in this case. It may be related to this reported bug https://bugs.chromium.org/p/chromium/issues/detail?id=1123301

This works around the bug by setting scrollLeft to 2 and then compare it against 2.

The following screenshots are taken when debugging this library on the same overflowing RTL container, demonstrating the problem and how the fix works around it. (Chrome Version 85.0.4183.83 on MacOS Version 10.15.6)
<img width="309" alt="Screen Shot 2020-09-02 at 8 17 27 pm" src="https://user-images.githubusercontent.com/8319596/92080240-8cef6300-ee04-11ea-8b9d-e300646898fb.png">

<img width="293" alt="Screen Shot 2020-09-03 at 2 41 18 pm" src="https://user-images.githubusercontent.com/8319596/92080249-911b8080-ee04-11ea-92b2-070d96b2eed0.png">
